### PR TITLE
Support optional machine alias besides the machine ID

### DIFF
--- a/src/update_engine/omaha_request_action.cc
+++ b/src/update_engine/omaha_request_action.cc
@@ -177,6 +177,7 @@ string GetAppXml(const OmahaEvent* event,
                 "oemversion=\"" + XmlEncode(params.oemversion()) + "\" " +
                 "alephversion=\"" + XmlEncode(params.alephversion()) + "\" " +
                 "machineid=\"" + XmlEncode(params.machineid()) + "\" " +
+                "machinealias=\"" + XmlEncode(params.machinealias()) + "\" " +
                 "lang=\"" + XmlEncode(params.app_lang()) + "\" " +
                 "board=\"" + XmlEncode(params.os_board()) + "\" " +
                 "hardware_class=\"" + XmlEncode(params.hwid()) + "\" " +

--- a/src/update_engine/omaha_request_params.cc
+++ b/src/update_engine/omaha_request_params.cc
@@ -51,6 +51,7 @@ bool OmahaRequestParams::Init(bool interactive) {
   app_lang_ = "en-US";
   bootid_ = utils::GetBootId();
   machineid_ = utils::GetMachineId();
+  machinealias_ = GetConfValue("MACHINE_ALIAS", "");
   update_url_ = GetConfValue("SERVER", kProductionOmahaUrl);
   pcr_policy_url_ = GetConfValue("PCR_POLICY_SERVER", "");
   download_user_ = GetConfValue("DOWNLOAD_USER", "");

--- a/src/update_engine/omaha_request_params.h
+++ b/src/update_engine/omaha_request_params.h
@@ -78,6 +78,7 @@ class OmahaRequestParams {
   inline std::string hwid() const { return hwid_; }
   inline std::string bootid() const { return bootid_; }
   inline std::string machineid() const { return machineid_; }
+  inline std::string machinealias() const { return machinealias_; }
   inline std::string oemid() const { return oemid_; }
   inline std::string oemversion() const { return oemversion_; }
   inline std::string alephversion() const { return alephversion_; }
@@ -152,6 +153,7 @@ class OmahaRequestParams {
   std::string hwid_;  // Hardware Qualification ID of the client
   std::string bootid_;  // Kernel generated guid that identifies this boot
   std::string machineid_; // Unique machine ID that is set during installation 
+  std::string machinealias_; // Custom alias for the machine (optional, the empty string will be ignored)
   std::string oemid_; // Unique machine ID that is set during installation 
   std::string oemversion_; // CoreOS version set during installation
   std::string alephversion_; // first CoreOS version cached by update_engine

--- a/systemd/update_engine_stub
+++ b/systemd/update_engine_stub
@@ -31,6 +31,7 @@ VERSION="${FLATCAR_RELEASE_VERSION}"
 : ${SERVER:="https://public.update.flatcar-linux.net/v1/update/"}
 : ${GROUP:="alpha"}
 : ${OEM_ID:="diskless"}
+: ${MACHINE_ALIAS:=""}
 
 fill_attrs() {
     echo -n "appid=\"${FLATCAR_RELEASE_APPID}\" "
@@ -40,6 +41,7 @@ fill_attrs() {
     echo -n "bootid=\"{${BOOT_ID}}\" "
     # other UUID's are surrounded by {} but not machineid
     echo -n "machineid=\"${MACHINE_ID}\" "
+    echo -n "machinealias=\"${MACHINE_ALIAS}\" "
     echo -n "lang=\"en-US\" "
     echo -n "hardware_class=\"\" "
     echo -n "delta_okay=\"false\" "


### PR DESCRIPTION
The machine ID is the unique identifier of a client but it does not
carry much information about the machine and is hard to remember or
compare for humans. Nebraska supports an optional machinealias Omaha
field to display besides the machine ID.
Allow to set a MACHINE_ALIAS variable in the update.conf file to
specify the machine_alias field and fall back to the empty string
otherwise which will be ignored by Nebraska. As with the other
variables in /etc/flatcar/update.conf the MACHINE_ALIAS variable can be
changed while update-engine runs and it will pick up the change, which
is useful for scripts that set the machine alias like this:
```
  sudo sed -i "/MACHINE_ALIAS=.*/d" /etc/flatcar/update.conf
  echo "MACHINE_ALIAS=$(hostname)" | sudo tee -a /etc/flatcar/update.conf

```
# How to use

Build an image and set the new variable and observe the effect in Nebraska.

# Testing done

Built an image and first steered the machine to a local Nebraska (set SERVER=http://…, FLATCAR_RELEASE_VERSION=3333.0.0, and GROUP=stable) and triggered an update to see that it registers (but doesn't update because there is no newer version), then added the machine alias variable and triggered an update again, seeing the alias set in Nebraska.