### PR TITLE
engine/update_attempter: init omaha request params

### DIFF
--- a/src/update_engine/update_attempter.cc
+++ b/src/update_engine/update_attempter.cc
@@ -125,7 +125,16 @@ UpdateAttempter::UpdateAttempter(SystemState* system_state,
 
 void UpdateAttempter::Update(bool interactive) {
   fake_update_success_ = false;
+
   if (status_ == UPDATE_STATUS_UPDATED_NEED_REBOOT) {
+    // we init the request_params to generate the correct payload
+    // and provide the correct `update_url`
+    http_response_code_ = 0;
+    if (!omaha_request_params_->Init(interactive)) {
+      LOG(ERROR) << "Unable to initialize Omaha request device params.";
+      return;
+    }
+
     // Although we have applied an update, we still want to ping Omaha
     // to ensure the number of active statistics is accurate.
     LOG(INFO) << "Not updating b/c we already updated and we're waiting for "


### PR DESCRIPTION
omaha request params were not loaded after a restart if the status
of the `update-engine` is set to UPDATE_STATUS_UPDATED_NEED_REBOOT.
It leads to ping Omaha server with missing values in the payload and
an empty update server url.

To not introduce side effect, we duplicated the init code to the "if"
section

Signed-off-by: Mathieu Tortuyaux <mathieu@kinvolk.io>

## Testing done (WIP)

Booted an image and assert that `update-engine` works as expected with "idle" status and "need reboot" status

closes https://github.com/kinvolk/Flatcar/issues/388
