### PR TITLE
src/update_engine_client: handle -update with idle

### DIFF
--- a/src/update_engine/update_engine_client.cc
+++ b/src/update_engine/update_engine_client.cc
@@ -186,9 +186,13 @@ bool CheckForUpdates() {
 
 static gboolean CompleteUpdateSource(gpointer data) {
   string current_op;
-  if (!GetStatus(&current_op) || current_op == "UPDATE_STATUS_IDLE") {
+  if (!GetStatus(&current_op)) {
     LOG(ERROR) << "Update failed.";
     exit(1);
+  }
+  if (current_op == "UPDATE_STATUS_IDLE") {
+    LOG(INFO) << "No update available";
+    exit(0);
   }
   if (current_op == "UPDATE_STATUS_UPDATED_NEED_REBOOT") {
     LOG(INFO) << "Update succeeded -- reboot needed.";


### PR DESCRIPTION
idle status was not correctly handled by the update_engine.

When a user wants to check for an update with `update_engine_client -update`
the command will fail with "Update failed" which can be misleading.
Actually, the update does not failed it is just cancelled because there
is no newer version.

Signed-off-by: Mathieu Tortuyaux <mathieu@kinvolk.io>

## How to use

build a Flatcar image using this commit in `coreos-base/update-engine` ebuild.

```
$ update_engine_client -update
I0702 14:33:22.542590   963 update_engine_client.cc:251] Initiating update check and install.
I0702 14:33:22.555794   963 update_engine_client.cc:256] Waiting for update to complete.
LAST_CHECKED_TIME=0
PROGRESS=0.000000
CURRENT_OP=UPDATE_STATUS_IDLE
NEW_VERSION=0.0.0
NEW_SIZE=0
I0702 14:33:28.111543   963 update_engine_client.cc:194] Update cancelled -- remote version is not newer than the local one
```
## Testing done

- https://github.com/kinvolk/mantle/pull/183


Closes https://github.com/kinvolk/Flatcar/issues/356
