### PR TITLE
Support btrfs as /usr filesystem

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: install deps
       run: |
-        sudo apt install -y libblkid-dev libext2fs-dev libmount-dev curl unzip libdbus-glib-1-dev protobuf-compiler libbz2-dev libgflags-dev libssl-dev libgoogle-glog-dev libcurl4-openssl-dev libxml2-dev libprotobuf-dev cmake wget libtool autoconf libgtest-dev libgmock-dev libbrotli-dev libdivsufsort-dev
+        sudo apt update && sudo apt install -y libblkid-dev libext2fs-dev libmount-dev curl unzip libdbus-glib-1-dev protobuf-compiler libbz2-dev libgflags-dev libssl-dev libgoogle-glog-dev libcurl4-openssl-dev libxml2-dev libprotobuf-dev cmake wget libtool autoconf libgtest-dev libgmock-dev libbrotli-dev libdivsufsort-dev
     - name: prep rootdev
       run: |
         curl -sSL -o /tmp/seismograph.zip https://github.com/kinvolk/seismograph/archive/flatcar-master.zip

--- a/src/update_engine/postinstall_runner_action.cc
+++ b/src/update_engine/postinstall_runner_action.cc
@@ -20,6 +20,7 @@ const char kPostinstallScript[] = "/postinst";
 
 void PostinstallRunnerAction::PerformAction() {
   CHECK(HasInputObject());
+  bool identical_partitions = false;
   const InstallPlan install_plan = GetInputObject();
   const string install_device = install_plan.partition_path;
   ScopedActionCompleter completer(processor_, this);
@@ -50,6 +51,18 @@ void PostinstallRunnerAction::PerformAction() {
                "btrfs",
                mountflags,
                "norecovery");
+    if (errno == EEXIST) {
+      /* When trying to mount an identical btrfs image twice because the old
+       * and new partition are identical, the kernel refuses because same UUIDs
+       * are linked to having a btrfs filesystem spread over multiple devices.
+       * Since the same image is used, we can run the postinstall action from
+       * the old/current partition. */
+      rc = 0;
+      /* We continue without mounting, but the destructor of
+       * ScopedTempUnmounter will still call the unmount which will fail
+       * silently. */
+      identical_partitions = true;
+    }
   }
   if (rc < 0) {
     LOG(ERROR) << "Unable to mount destination device " << install_device
@@ -63,7 +76,7 @@ void PostinstallRunnerAction::PerformAction() {
   // Runs the postinstall script asynchronously to free up the main loop while
   // it's running.
   vector<string> command;
-  command.push_back(temp_rootfs_dir_ + kPostinstallScript);
+  command.push_back((identical_partitions ? "/usr" : temp_rootfs_dir_) + kPostinstallScript);
   command.push_back(install_device);
   command.insert(command.end(),
                  install_plan.postinst_args.begin(),

--- a/src/update_engine/postinstall_runner_action.cc
+++ b/src/update_engine/postinstall_runner_action.cc
@@ -44,6 +44,14 @@ void PostinstallRunnerAction::PerformAction() {
                NULL);
   }
   if (rc < 0) {
+    LOG(INFO) << "Failed to mount install part as ext2/ext3. Trying btrfs.";
+    rc = mount(install_device.c_str(),
+               temp_rootfs_dir_.c_str(),
+               "btrfs",
+               mountflags,
+               "norecovery");
+  }
+  if (rc < 0) {
     LOG(ERROR) << "Unable to mount destination device " << install_device
                << " onto " << temp_rootfs_dir_;
     return;


### PR DESCRIPTION
- postinstall: support btrfs as /usr filesystem
    
    When btrfs is used to fit more content into the partition, mounting
    fails because ext2/3 was hardcoded.
    Also try to mount as btrfs if mounting as ext2/3 fails. The
    norecovery options makes sure that the filesystem isn't touched even if
    the it is corrupted.
- utils: support btrfs
    
    With btrfs it's not possible in general to find a single underlying
    block device because there could be many, but still it is possible for
    our case since we have a single partition. However, rootdev failed to
    find it because it uses the device minor and major pair from a "stat"
    syscall on the mount point. This doesn't work with btrfs because it
    gives a logical pair instead of one belonging to a block device.
    
    Instead of using the minor and major pair, find the underlying block
    device of a mount point by looking it up in /proc/mounts. The existing
    traversal code to find the lowest backing device is kept in place by
    getting the minor and major pair for the found block device.
    
    Based on the new code in seismograph's rootdev under src/rootdev/main.c from https://github.com/kinvolk/seismograph/pull/6

## How to use/Testing done

This was built and tested with the coreos-overlay branch `kai/bootengine-verity-hashoffset` from https://github.com/kinvolk/coreos-overlay/pull/1106 and flatcar-scripts branch `kai/btrfs-usr-oem` from https://github.com/kinvolk/flatcar-scripts/pull/131 in http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3029/cldsv/ where the Flatcar image that has a btrfs /usr partition and OEM partition.
While the actual switch to a btrfs filesystem on the /usr partition is only possible when all changes are part of a Stable release because update-engine needs to know how to handle the new filesystem when updating, we can already do the switch for the OEM partition.