### PR TITLE
add postinstall hook to stay on cgroupv1

### DIFF
--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -329,7 +329,7 @@ function patch_grub {
 patch_grub
 
 # Keep old nodes on cgroup v1
-if ! grep -q systemd.unified_cgroup_hierarchy "${OEM_MNT}/grub.cfg"; then
+if ! grep -q systemd.unified_cgroup_hierarchy "${OEM_MNT}/grub.cfg" 2>/dev/null; then
     # if there is an explicit setting, don't touch it. Otherwise...
     if [[ "${VERSION_ID}" != *"nightly"* ]]; then
         if [ "${VERSION_ID%%.*}" -lt 2943 ]; then

--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -339,7 +339,7 @@ if [[ "${BUILD_ID}" != "dev-"* ]]; then
 # Automatically added during update from ${VERSION_ID} to ${NEXT_VERSION_ID}
 # Flatcar has migrated to cgroup v2. Your node has been kept on cgroup v1.
 # Migrate at your own convenience by changing the value to '=1', or remove this
-# line if you don't need to switch back.
+# line if you don't need to switch back ('systemd.legacy_systemd_cgroup_controller' only has effect for `=0`).
 # For more details visit:
 # https://kinvolk.io/docs/flatcar-container-linux/latest/container-runtimes/switching-to-unified-cgroups
 set linux_append="\$linux_append systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller"
@@ -351,7 +351,7 @@ EOF
 	   ( systemctl show -p Environment containerd | \
 	     grep -qF 'CONTAINERD_CONFIG=/usr/share/containerd/config.toml' ); then
             mkdir -p /etc/systemd/system/containerd.service.d/
-	    cat >>/etc/systemd/system/containerd.service.d/10-use-cgroupfs.conf <<EOF
+	    cat >/etc/systemd/system/containerd.service.d/10-use-cgroupfs.conf <<EOF
 # Automatically created during update from ${VERSION_ID} to ${NEXT_VERSION_ID}
 # Flatcar has migrated to cgroup v2. Your node has been kept on cgroup v1.
 # For more details visit:

--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -337,7 +337,8 @@ if ! grep -q systemd.unified_cgroup_hierarchy "${OEM_MNT}/grub.cfg" 2>/dev/null;
 
 # Automatically added during update from ${VERSION_ID} to ${NEXT_VERSION_ID}
 # Flatcar has migrated to cgroup v2. Your node has been kept on cgroup v1.
-# Migrate at your own convenience by changing the value to '=1'
+# Migrate at your own convenience by changing the value to '=1', or remove this
+# line if you don't need to switch back.
 # For more details visit:
 # https://kinvolk.io/docs/flatcar-container-linux/latest/container-runtimes/switching-to-unified-cgroups
 set linux_append="\$linux_append systemd.unified_cgroup_hierarchy=0"

--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -328,6 +328,25 @@ function patch_grub {
 
 patch_grub
 
+# Keep old nodes on cgroup v1
+if ! grep -q systemd.unified_cgroup_hierarchy "${OEM_MNT}/grub.cfg"; then
+    # if there is an explicit setting, don't touch it. Otherwise...
+    if [[ "${VERSION_ID}" != *"nightly"* ]]; then
+        if [ "${VERSION_ID%%.*}" -lt 2943 ]; then
+            cat >>"${OEM_MNT}/grub.cfg" <<EOF
+
+# Automatically added during update from ${VERSION_ID} to ${NEXT_VERSION_ID}
+# Flatcar has migrated to cgroup v2. Your node has been kept on cgroup v1.
+# Migrate at your own convenience by changing the value to '=1'
+# For more details visit:
+# https://kinvolk.io/docs/flatcar-container-linux/latest/container-runtimes/switching-to-unified-cgroups
+set linux_append="\$linux_append systemd.unified_cgroup_hierarchy=0"
+EOF
+        fi
+    fi
+fi
+
+
 # The vmware OEM on Container Linux 490.0.0 - 1353.8.0 includes a build of
 # open-vm-tools with a dlopened plugin that links with the libprocps.so.3
 # shipped in /usr. When upgrading to CL > 1786, which no longer carries

--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -329,10 +329,11 @@ function patch_grub {
 patch_grub
 
 # Keep old nodes on cgroup v1
-if ! grep -q systemd.unified_cgroup_hierarchy "${OEM_MNT}/grub.cfg" 2>/dev/null; then
-    # if there is an explicit setting, don't touch it. Otherwise...
-    if [[ "${BUILD_ID}" != "dev-"* ]]; then
-        if [ "${VERSION_ID%%.*}" -lt 2956 ]; then
+if [[ "${BUILD_ID}" != "dev-"* ]]; then
+    if [ "${VERSION_ID%%.*}" -lt 2956 ]; then
+
+        # if there is an explicit setting, don't touch it. Otherwise...
+        if ! grep -q systemd.unified_cgroup_hierarchy "${OEM_MNT}/grub.cfg" 2>/dev/null; then
             cat >>"${OEM_MNT}/grub.cfg" <<EOF
 
 # Automatically added during update from ${VERSION_ID} to ${NEXT_VERSION_ID}
@@ -344,6 +345,21 @@ if ! grep -q systemd.unified_cgroup_hierarchy "${OEM_MNT}/grub.cfg" 2>/dev/null;
 set linux_append="\$linux_append systemd.unified_cgroup_hierarchy=0"
 EOF
         fi
+
+	if ( systemctl show -p ExecStart containerd | \
+             grep -qF '/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/containerd --config ${TORCX_UNPACKDIR}${TORCX_IMAGEDIR}${CONTAINERD_CONFIG}' ) && \
+	   ( systemctl show -p Environment containerd | \
+	     grep -qF 'CONTAINERD_CONFIG=/usr/share/containerd/config.toml' ); then
+            mkdir -p /etc/systemd/system/containerd.service.d/
+	    cat >>/etc/systemd/system/containerd.service.d/10-use-cgroupfs.conf <<EOF
+# Automatically created during update from ${VERSION_ID} to ${NEXT_VERSION_ID}
+# Flatcar has migrated to cgroup v2. Your node has been kept on cgroup v1.
+# For more details visit:
+# https://kinvolk.io/docs/flatcar-container-linux/latest/container-runtimes/switching-to-unified-cgroups
+[Service]
+Environment=CONTAINERD_CONFIG=/usr/share/containerd/config-cgroupfs.toml
+EOF
+	fi
     fi
 fi
 

--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -342,7 +342,7 @@ if [[ "${BUILD_ID}" != "dev-"* ]]; then
 # line if you don't need to switch back.
 # For more details visit:
 # https://kinvolk.io/docs/flatcar-container-linux/latest/container-runtimes/switching-to-unified-cgroups
-set linux_append="\$linux_append systemd.unified_cgroup_hierarchy=0"
+set linux_append="\$linux_append systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller"
 EOF
         fi
 

--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -331,7 +331,7 @@ patch_grub
 # Keep old nodes on cgroup v1
 if ! grep -q systemd.unified_cgroup_hierarchy "${OEM_MNT}/grub.cfg" 2>/dev/null; then
     # if there is an explicit setting, don't touch it. Otherwise...
-    if [[ "${VERSION_ID}" != *"nightly"* ]]; then
+    if [[ "${BUILD_ID}" != "dev-"* ]]; then
         if [ "${VERSION_ID%%.*}" -lt 2956 ]; then
             cat >>"${OEM_MNT}/grub.cfg" <<EOF
 

--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -332,7 +332,7 @@ patch_grub
 if ! grep -q systemd.unified_cgroup_hierarchy "${OEM_MNT}/grub.cfg" 2>/dev/null; then
     # if there is an explicit setting, don't touch it. Otherwise...
     if [[ "${VERSION_ID}" != *"nightly"* ]]; then
-        if [ "${VERSION_ID%%.*}" -lt 2943 ]; then
+        if [ "${VERSION_ID%%.*}" -lt 2956 ]; then
             cat >>"${OEM_MNT}/grub.cfg" <<EOF
 
 # Automatically added during update from ${VERSION_ID} to ${NEXT_VERSION_ID}


### PR DESCRIPTION
# add postinstall hook to stay on cgroupv1

Changing cgroup setting on a provisioned system is guaranteed to cause trouble with kuberntes clusters. In order to not disturb operations during a routing update, a postinstall hook is added that modifies the OEM grub.cfg to keep the system on cgroupv1. This will allow us to migrate the alpha channel to cgroupv2.

Part of kinvolk/coreos-overlay#931

## How to use

Boot alpha 2942.0.0.
Use https://github.com/kinvolk/Flatcar/issues/70#issuecomment-880441082 to update to a development snapshot containing this change.